### PR TITLE
macOS でのアプリ名の表記を設定した

### DIFF
--- a/macOS/Xemime.app/Contents/Info.plist
+++ b/macOS/Xemime.app/Contents/Info.plist
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>CFBundleDisplayName</key>
+    <string>Xemime</string>
+    <key>CFBundleName</key>
+    <string>Xemime</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0 PA</string>
+    <key>CFBundleVersion</key>
+    <string>0.1.0 Pre-Alpha</string>
     <key>CFBundleExecutable</key>
     <string>launch.sh</string>
     <key>CFBundlePackageType</key>


### PR DESCRIPTION
Fixes #2 